### PR TITLE
Improve color scheme and splash screen

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -38,7 +38,7 @@ export function Header() {
         <div className="relative">
           <button type="button" className="-m-1.5 flex items-center p-1.5">
             <span className="sr-only">Open user menu</span>
-            <div className="h-8 w-8 rounded-full bg-gradient-to-br from-blue-600 to-purple-600 flex items-center justify-center">
+            <div className="h-8 w-8 rounded-full bg-gradient-to-br from-teal-500 to-indigo-600 flex items-center justify-center">
               <span className="text-sm font-medium text-white">JD</span>
             </div>
             <span className="hidden lg:flex lg:items-center">

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -7,20 +7,20 @@ interface LoadingScreenProps {
 
 export function LoadingScreen({ message = 'Loading...' }: LoadingScreenProps) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 flex items-center justify-center">
+    <div className="min-h-screen bg-gradient-to-br from-teal-50 via-white to-indigo-50 flex items-center justify-center">
       <div className="text-center">
         <div className="relative mb-8">
-          <div className="flex h-20 w-20 items-center justify-center rounded-full bg-gradient-to-br from-blue-600 to-purple-600 mx-auto animate-pulse">
+          <div className="flex h-20 w-20 items-center justify-center rounded-full bg-gradient-to-br from-teal-500 to-indigo-600 mx-auto animate-pulse">
             <Vault className="h-10 w-10 text-white" />
           </div>
-          <div className="absolute inset-0 rounded-full border-4 border-blue-200 animate-spin border-t-blue-600"></div>
+          <div className="absolute inset-0 rounded-full border-4 border-teal-200 animate-spin border-t-teal-500"></div>
         </div>
         
         <h1 className="text-2xl font-bold text-gray-900 mb-2">Vault of Legacy</h1>
         <p className="text-gray-600 mb-6">{message}</p>
         
         <div className="flex items-center justify-center space-x-2">
-          <Loader2 className="h-4 w-4 animate-spin text-blue-600" />
+          <Loader2 className="h-4 w-4 animate-spin text-teal-600" />
           <span className="text-sm text-gray-500">Initializing secure connection...</span>
         </div>
         
@@ -29,7 +29,7 @@ export function LoadingScreen({ message = 'Loading...' }: LoadingScreenProps) {
             {[0, 1, 2].map((i) => (
               <div
                 key={i}
-                className="h-2 w-2 bg-blue-600 rounded-full animate-bounce"
+                className="h-2 w-2 bg-teal-600 rounded-full animate-bounce"
                 style={{ animationDelay: `${i * 0.1}s` }}
               ></div>
             ))}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -47,7 +47,7 @@ function classNames(...classes: string[]) {
       <div className="flex grow flex-col gap-y-5 overflow-y-auto bg-white px-6 pb-4 shadow-xl">
         <div className="flex h-16 shrink-0 items-center">
           <div className="flex items-center space-x-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br from-blue-600 to-purple-600">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br from-teal-500 to-indigo-600">
               <Vault className="h-6 w-6 text-white" />
             </div>
             <div>
@@ -66,14 +66,14 @@ function classNames(...classes: string[]) {
                       onClick={() => onPageChange(item.page)}
                       className={classNames(
                         currentPage === item.page
-                          ? 'bg-blue-50 text-blue-700 border-r-2 border-blue-600'
-                          : 'text-gray-700 hover:text-blue-600 hover:bg-gray-50',
+                          ? 'bg-teal-50 text-teal-700 border-r-2 border-teal-600'
+                          : 'text-gray-700 hover:text-teal-600 hover:bg-gray-50',
                         'group flex gap-x-3 rounded-l-md p-3 text-sm leading-6 font-medium transition-colors duration-200 w-full text-left'
                       )}
                     >
                       <item.icon
                         className={classNames(
-                          currentPage === item.page ? 'text-blue-600' : 'text-gray-400 group-hover:text-blue-600',
+                          currentPage === item.page ? 'text-teal-600' : 'text-gray-400 group-hover:text-teal-600',
                           'h-5 w-5 shrink-0'
                         )}
                         aria-hidden="true"

--- a/src/components/auth/ForgotPasswordForm.tsx
+++ b/src/components/auth/ForgotPasswordForm.tsx
@@ -19,7 +19,7 @@ export function ForgotPasswordForm({ onSwitchToLogin }: ForgotPasswordFormProps)
 
   if (isSubmitted) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="min-h-screen bg-gradient-to-br from-teal-50 via-white to-indigo-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
         <div className="max-w-md w-full space-y-8 text-center">
           <div>
             <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-100 mx-auto mb-4">
@@ -39,7 +39,7 @@ export function ForgotPasswordForm({ onSwitchToLogin }: ForgotPasswordFormProps)
 
           <button
             onClick={onSwitchToLogin}
-            className="flex items-center justify-center space-x-2 text-blue-600 hover:text-blue-500 font-medium"
+            className="flex items-center justify-center space-x-2 text-teal-600 hover:text-teal-500 font-medium"
           >
             <ArrowLeft className="h-4 w-4" />
             <span>Back to sign in</span>
@@ -50,10 +50,10 @@ export function ForgotPasswordForm({ onSwitchToLogin }: ForgotPasswordFormProps)
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gradient-to-br from-teal-50 via-white to-indigo-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
-          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-blue-600 to-purple-600 mx-auto mb-4">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-teal-500 to-indigo-600 mx-auto mb-4">
             <Vault className="h-8 w-8 text-white" />
           </div>
           <h2 className="text-3xl font-bold text-gray-900">Forgot password?</h2>
@@ -90,7 +90,7 @@ export function ForgotPasswordForm({ onSwitchToLogin }: ForgotPasswordFormProps)
                 required
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+                className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent transition-colors duration-200"
                 placeholder="Enter your email address"
               />
             </div>
@@ -99,7 +99,7 @@ export function ForgotPasswordForm({ onSwitchToLogin }: ForgotPasswordFormProps)
           <button
             type="submit"
             disabled={isLoading}
-            className="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
+            className="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-gradient-to-r from-teal-500 to-indigo-600 hover:from-teal-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
           >
             {isLoading ? (
               <Loader2 className="h-5 w-5 animate-spin" />

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -19,10 +19,10 @@ export function LoginForm({ onSwitchToSignup, onSwitchToForgotPassword }: LoginF
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gradient-to-br from-teal-50 via-white to-indigo-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
-          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-blue-600 to-purple-600 mx-auto mb-4">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-teal-500 to-indigo-600 mx-auto mb-4">
             <Vault className="h-8 w-8 text-white" />
           </div>
           <h2 className="text-3xl font-bold text-gray-900">Welcome back</h2>
@@ -58,7 +58,7 @@ export function LoginForm({ onSwitchToSignup, onSwitchToForgotPassword }: LoginF
                   required
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+                  className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent transition-colors duration-200"
                   placeholder="Enter your email"
                 />
               </div>
@@ -80,7 +80,7 @@ export function LoginForm({ onSwitchToSignup, onSwitchToForgotPassword }: LoginF
                   required
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="block w-full pl-10 pr-10 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+                  className="block w-full pl-10 pr-10 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent transition-colors duration-200"
                   placeholder="Enter your password"
                 />
                 <button
@@ -104,7 +104,7 @@ export function LoginForm({ onSwitchToSignup, onSwitchToForgotPassword }: LoginF
                 id="remember-me"
                 name="remember-me"
                 type="checkbox"
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+              className="h-4 w-4 text-teal-600 focus:ring-teal-500 border-gray-300 rounded"
               />
               <label htmlFor="remember-me" className="ml-2 block text-sm text-gray-700">
                 Remember me
@@ -114,7 +114,7 @@ export function LoginForm({ onSwitchToSignup, onSwitchToForgotPassword }: LoginF
             <button
               type="button"
               onClick={onSwitchToForgotPassword}
-              className="text-sm text-blue-600 hover:text-blue-500 font-medium"
+              className="text-sm text-teal-600 hover:text-teal-500 font-medium"
             >
               Forgot password?
             </button>
@@ -123,7 +123,7 @@ export function LoginForm({ onSwitchToSignup, onSwitchToForgotPassword }: LoginF
           <button
             type="submit"
             disabled={isLoading}
-            className="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
+            className="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-gradient-to-r from-teal-500 to-indigo-600 hover:from-teal-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
           >
             {isLoading ? (
               <Loader2 className="h-5 w-5 animate-spin" />
@@ -137,7 +137,7 @@ export function LoginForm({ onSwitchToSignup, onSwitchToForgotPassword }: LoginF
             <button
               type="button"
               onClick={onSwitchToSignup}
-              className="text-sm text-blue-600 hover:text-blue-500 font-medium"
+              className="text-sm text-teal-600 hover:text-teal-500 font-medium"
             >
               Sign up
             </button>

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -41,10 +41,10 @@ export function SignupForm({ onSwitchToLogin }: SignupFormProps) {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gradient-to-br from-teal-50 via-white to-indigo-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
-          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-blue-600 to-purple-600 mx-auto mb-4">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-teal-500 to-indigo-600 mx-auto mb-4">
             <Vault className="h-8 w-8 text-white" />
           </div>
           <h2 className="text-3xl font-bold text-gray-900">Create your account</h2>
@@ -80,7 +80,7 @@ export function SignupForm({ onSwitchToLogin }: SignupFormProps) {
                   required
                   value={formData.name}
                   onChange={handleChange}
-                  className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+                  className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent transition-colors duration-200"
                   placeholder="Enter your full name"
                 />
               </div>
@@ -102,7 +102,7 @@ export function SignupForm({ onSwitchToLogin }: SignupFormProps) {
                   required
                   value={formData.email}
                   onChange={handleChange}
-                  className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+                  className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent transition-colors duration-200"
                   placeholder="Enter your email"
                 />
               </div>
@@ -124,7 +124,7 @@ export function SignupForm({ onSwitchToLogin }: SignupFormProps) {
                   required
                   value={formData.password}
                   onChange={handleChange}
-                  className="block w-full pl-10 pr-10 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+                  className="block w-full pl-10 pr-10 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent transition-colors duration-200"
                   placeholder="Create a password"
                 />
                 <button
@@ -168,7 +168,7 @@ export function SignupForm({ onSwitchToLogin }: SignupFormProps) {
                   required
                   value={formData.confirmPassword}
                   onChange={handleChange}
-                  className="block w-full pl-10 pr-10 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+                  className="block w-full pl-10 pr-10 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent transition-colors duration-200"
                   placeholder="Confirm your password"
                 />
                 <button
@@ -195,20 +195,20 @@ export function SignupForm({ onSwitchToLogin }: SignupFormProps) {
               name="terms"
               type="checkbox"
               required
-              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+              className="h-4 w-4 text-teal-600 focus:ring-teal-500 border-gray-300 rounded"
             />
             <label htmlFor="terms" className="ml-2 block text-sm text-gray-700">
               I agree to the{' '}
-              <a href="#" className="text-blue-600 hover:text-blue-500">Terms of Service</a>
+              <a href="#" className="text-teal-600 hover:text-teal-500">Terms of Service</a>
               {' '}and{' '}
-              <a href="#" className="text-blue-600 hover:text-blue-500">Privacy Policy</a>
+              <a href="#" className="text-teal-600 hover:text-teal-500">Privacy Policy</a>
             </label>
           </div>
 
           <button
             type="submit"
             disabled={isLoading || formData.password !== formData.confirmPassword}
-            className="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
+            className="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-gradient-to-r from-teal-500 to-indigo-600 hover:from-teal-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
           >
             {isLoading ? (
               <Loader2 className="h-5 w-5 animate-spin" />
@@ -222,7 +222,7 @@ export function SignupForm({ onSwitchToLogin }: SignupFormProps) {
             <button
               type="button"
               onClick={onSwitchToLogin}
-              className="text-sm text-blue-600 hover:text-blue-500 font-medium"
+              className="text-sm text-teal-600 hover:text-teal-500 font-medium"
             >
               Sign in
             </button>


### PR DESCRIPTION
## Summary
- modernize loading screen gradient colors
- update login/signup/forgot password pages with teal & indigo gradients
- change navigation and header gradients to match new theme

## Testing
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68731e0b6bb48332a08a2f16d79cbfb8